### PR TITLE
Composer support #51

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,38 @@
+{
+    "name": "components/jquery-smallipop",
+    "description": "Tooltip Popup for jQuery",
+    "keywords": ["jquery", "tooltip", "css", "animation"],
+    "homepage": "http://projects.sebastianhelzle.net/jquery.smallipop/",
+    "license": "MIT",
+	"type": "component",
+    "authors": [
+        {
+            "name": "Sebastian Helzle",
+            "email": "sebastian@small-improvements.com"
+        }
+    ],
+    "require": {
+        "robloach/component-installer": "*",
+		"components/jquery": ">1.5.2",
+        "components/modernizr": "dev-master"
+    },
+    "extra": {
+        "component": {
+            "scripts": [
+                "lib/jquery.smallipop.js",
+                "lib/main.js"
+            ],
+            "styles": [
+                "css/jquery.smallipop.css",
+                "css/jquery.smallipop.min.css",
+                "css/screen.css",
+                "css/contrib/animate.min.css"
+            ],
+            "files": [
+                "lib/jquery.smallipop.min.js",
+                "images/*.png",
+                "images/pic1.jpg"
+            ]
+        }
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     ],
     "require": {
         "robloach/component-installer": "*",
-		"components/jquery": ">1.5.2",
+        "components/jquery": ">1.5.2",
         "components/modernizr": "dev-master"
     },
     "extra": {

--- a/composer.json
+++ b/composer.json
@@ -19,19 +19,15 @@
     "extra": {
         "component": {
             "scripts": [
-                "lib/jquery.smallipop.js",
-                "lib/main.js"
+                "lib/jquery.smallipop.js"
             ],
             "styles": [
                 "css/jquery.smallipop.css",
-                "css/jquery.smallipop.min.css",
-                "css/screen.css",
                 "css/contrib/animate.min.css"
             ],
             "files": [
                 "lib/jquery.smallipop.min.js",
-                "images/*.png",
-                "images/pic1.jpg"
+                "css/jquery.smallipop.min.css"
             ]
         }
     }


### PR DESCRIPTION
Added composer.json to allow for publishing this package on packagist. component-installer is used to place both JavaScript and CSS files to the components/ folder of composer-based installations.

If I understood documentation correctly, only `lib/jquery.smallipop.js`, `css/jquery.smallipop.css` and `ss/contrib/animate.min.css` as well as the minified version of both the JS and CSS file of smallipop. 

The composer.json file requires the installation of jquery >1.5.2, and the most recent version of modernizr. Further, it requires " component-installer", for the purpose of placing the JS and CSS files to the correct folders.
